### PR TITLE
Propagate request validation error to the error middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function procRequest (type, options, schema, req, res, next) {
 
   function validateRequest (err, value) {
     return err
-      ? res.status(400).send(err.message)
+      ? res.status(400) && next(err)
       : (req[type] = value) && next()
   }
 }

--- a/test.js
+++ b/test.js
@@ -91,6 +91,7 @@ describe('express midlleware schema validator', () => {
 
       app.use(bodyParser.json())
       app.use('/request', router)
+      app.use((err, req, res, next) => res.send(err.message))
 
       done()
     })


### PR DESCRIPTION
Hi,

Request validation error could be propagated to the error middleware, so that the application using this module has the ability to choose how to treat this kind of errors.

Thanks